### PR TITLE
Use exec instead of sh -c to run npm

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 
-sh -c "npm $*"
+exec npm "$@"


### PR DESCRIPTION
Bonus: this will work if any of the command args have spaces or chars that sh doesn't
like, without additional quoting.